### PR TITLE
cassandra: Increase stack size to fix startup

### DIFF
--- a/cassandra/module.py
+++ b/cassandra/module.py
@@ -9,7 +9,7 @@ default = api.run_java(
         '-Xmx1968M',
         '-Xmn400M',
         '-XX:+HeapDumpOnOutOfMemoryError',
-        '-Xss180k',
+        '-Xss228k',
         '-XX:+UseParNewGC',
         '-XX:+UseConcMarkSweepGC',
         '-XX:+CMSParallelRemarkEnabled',


### PR DESCRIPTION
The lastest JVM in osv.git refuses to start up an application with 180k
stack size.  Bump it up to the required minimum to make Cassandra start
up again.

Signed-off-by: Pekka Enberg penberg@cloudius-systems.com
