### PR TITLE
cassandra: Fix JNA link errors by downgrading to 3.2.7

### DIFF
--- a/cassandra/GET
+++ b/cassandra/GET
@@ -10,6 +10,6 @@ cd apache-cassandra-$VERSION
 patch -p1 < ../../cassandra-osv.patch
 cd ..
 
-wget https://maven.java.net/content/repositories/releases/net/java/dev/jna/jna/4.0.0/jna-4.0.0.jar
+wget http://download.java.net/maven/2/net/java/dev/jna/jna/3.2.7/jna-3.2.7.jar
 cd ..
 #rm -r upstream

--- a/cassandra/usr.manifest
+++ b/cassandra/usr.manifest
@@ -1,3 +1,3 @@
 /usr/cassandra/lib/**: ${MODULE_DIR}/upstream/apache-cassandra-1.2.6/lib/**
 /usr/cassandra/conf/**: ${MODULE_DIR}/upstream/apache-cassandra-1.2.6/conf/**
-/usr/cassandra/lib/jna-4.0.0.jar: ${MODULE_DIR}/upstream/jna-4.0.0.jar
+/usr/cassandra/lib/jna-3.2.7.jar: ${MODULE_DIR}/upstream/jna-3.2.7.jar


### PR DESCRIPTION
Use JNA 3.2.7 which is what I was using with Cassandra earlier to
resolve link errors.

Signed-off-by: Pekka Enberg penberg@cloudius-systems.com
