### PR TITLE
Fix typo in minecraft-server README

### DIFF
--- a/minecraft-server/README
+++ b/minecraft-server/README
@@ -1,5 +1,5 @@
 How to run Minecraft Server:
-$ ./GEN
+$ ./GET
 Check EULA
 
 $ java -Xmx1024M -Xmx1024M -jar minecraft_server.1.7.10.jar nogui


### PR DESCRIPTION
Previously said "./GEN" vs "./GET"
