### PR TITLE
erlang: change configure options

### DIFF
--- a/erlang/Capstanfile
+++ b/erlang/Capstanfile
@@ -1,2 +1,2 @@
-base: osv-empty
-cmdline: --env=BINDIR=/usr/lib/erlang/erts-6.2/bin /usr/lib/erlang/erts-6.2/bin/beam -- -root /usr/lib/erlang -progname erl -- -home / --
+base: cloudius/osv-base
+cmdline: --env=BINDIR=/usr/lib64/erlang/erts-6.2/bin /usr/lib64/erlang/erts-6.2/bin/beam.smp -K true -- -root /usr/lib64/erlang -progname erl -- -home / --

--- a/erlang/Makefile
+++ b/erlang/Makefile
@@ -13,7 +13,7 @@ otp_src_$(OTP_VERSION): otp_src_$(OTP_VERSION).tar.gz
 	tar xvf "$<"
 
 configure: otp_src_$(OTP_VERSION)
-	cd otp_src_$(OTP_VERSION); export ERL_TOP=$(CURDIR)/otp_src_$(OTP_VERSION) CFLAGS=-fpie LDFLAGS=-pie; ./configure -prefix=/usr --disable-silent-rules --disable-threads --disable-smp-support --disable-kernel-poll --disable-sctp --disable-hipe --disable-megaco-flex-scanner-lineno --disable-megaco-reentrant-flex-scanner --enable-builtin-zlib --without-termcap --without-javac --without-ssl --without-wx --without-asn1 --without-common_test --without-cosEvent --without-cosEventDomain --without-cosFileTransfer --without-cosNotification --without-cosProperty --without-cosTime --without-cosTransactions --without-crypto --without-debugger --without-dialyzer --without-diameter --without-edoc --without-eldap --without-erl_docgen --without-erl_interface --without-et --without-eunit --without-gs --without-hipe --without-ic --without-jinterface --without-megaco --without-mnesia --without-observer --without-odbc --without-orber --without-ose --without-os_mon --without-otp_mibs --without-percept --without-public_key --without-snmp --without-ssl --without-ssl --without-test_server --without-tools --without-typer --without-webtool --without-xmerl
+	cd otp_src_$(OTP_VERSION); export ERL_TOP=$(CURDIR)/otp_src_$(OTP_VERSION) CFLAGS=-fpie LDFLAGS=-pie; ./configure -prefix=/usr --libdir=/usr/lib64 --disable-hipe --without-hipe --without-odbc --without-os_mon --enable-builtin-zlib --without-termcap --without-wx --without-erl_interface --without-javac --without-jinterface
 
 compile: configure
 	mkdir -p ROOTFS
@@ -21,6 +21,7 @@ compile: configure
 
 install: compile
 	cd otp_src_$(OTP_VERSION); export ERL_TOP=$(CURDIR)/otp_src_$(OTP_VERSION) DESTDIR=$(CURDIR)/ROOTFS; make install
+	find ROOTFS -name '*.so' | xargs -I {} ldd {} | grep -Po '(?<=> )/[^ ]+' | sort | uniq | grep -Pv 'lib(c|dl|m|util|rt|pthread).so' | xargs -I {} install -D -T {} ROOTFS{}
 
 clean:
 	-rm -rf ROOTFS

--- a/erlang/module.py
+++ b/erlang/module.py
@@ -1,3 +1,3 @@
 from osv.modules import api
 
-default = api.run(cmdline="--env=BINDIR=/usr/lib64/erlang/erts-6.2/bin /usr/lib64/erlang/erts-6.2/bin/beam -- -root /usr/lib64/erlang -progname erl -- -home / --")
+default = api.run(cmdline="--env=BINDIR=/usr/lib64/erlang/erts-6.2/bin /usr/lib64/erlang/erts-6.2/bin/beam.smp -K true -- -root /usr/lib64/erlang -progname erl -- -home / --")


### PR DESCRIPTION
enable erlang smp support, change libdir to /usr/lib64, enable ssl and
many other libraries

Signed-off-by: bhuztez bhuztez@gmail.com
