### PR TITLE
erlang: enable memsup and disksup in os_mon

### DIFF
--- a/erlang/Makefile
+++ b/erlang/Makefile
@@ -22,6 +22,9 @@ compile: configure
 install: compile
 	cd otp_src_$(OTP_VERSION); export ERL_TOP=$(CURDIR)/otp_src_$(OTP_VERSION) DESTDIR=$(CURDIR)/ROOTFS; make install
 	find ROOTFS -name '*.so' | xargs -I {} ldd {} | grep -Po '(?<=> )/[^ ]+' | sort | uniq | grep -Pv 'lib(c|dl|m|util|rt|pthread).so' | xargs -I {} install -D -T {} ROOTFS{}
+	make -C os_mon
+	mkdir -p $(CURDIR)/ROOTFS/usr/lib64/erlang/lib/os_mon-2.3
+	cd os_mon; cp --parents -u -r -t $(CURDIR)/ROOTFS/usr/lib64/erlang/lib/os_mon-2.3 ebin/* src/* priv/*
 
 clean:
 	-rm -rf ROOTFS

--- a/erlang/os_mon/.gitignore
+++ b/erlang/os_mon/.gitignore
@@ -1,0 +1,2 @@
+priv/
+*.beam

--- a/erlang/os_mon/Makefile
+++ b/erlang/os_mon/Makefile
@@ -1,0 +1,20 @@
+OTP_VERSION=17.3
+ERLS=$(wildcard src/*.erl)
+BEAMS=$(ERLS:src/%.erl=ebin/%.beam)
+C_SRCS=$(wildcard c_src/*.c)
+DRIVERS=$(C_SRCS:c_src/%.c=priv/lib/%.so)
+ROOTFS=../ROOTFS
+
+all: $(BEAMS) $(DRIVERS)
+
+priv/lib/%.so: c_src/%.c | priv/lib
+	gcc -o "$@" -I$(ROOTFS)/usr/lib64/erlang/usr/include -Wall -Wextra -Werror -fPIC -shared "$<"
+
+priv/lib:
+	mkdir -p priv/lib
+
+ebin/%.beam: src/%.erl
+	../otp_src_$(OTP_VERSION)/bin/erlc -Iinclude -o ebin "$<"
+
+clean:
+	rm -rf ebin/*.beam priv/lib/*.so

--- a/erlang/os_mon/c_src/disksup.c
+++ b/erlang/os_mon/c_src/disksup.c
@@ -1,0 +1,150 @@
+#include <string.h>
+#include <sys/param.h>
+#include <sys/statvfs.h>
+#include <mntent.h>
+#include <erl_driver.h>
+
+
+struct driver_data {
+  ErlDrvPort port;
+  ErlDrvTermData port_term;
+};
+
+
+struct disk_data {
+  char *disk_path;
+  size_t disk_path_len;
+  size_t disk_size;
+  int disk_usage;
+  struct disk_data *next;
+};
+
+
+struct async_data {
+  struct disk_data *disk_data;
+  size_t entries;
+};
+
+
+static ErlDrvData disksup_start(ErlDrvPort port, char *buff __attribute__((unused)) ) {
+  struct driver_data *driver_data = (struct driver_data *)driver_alloc(sizeof(struct driver_data));
+  driver_data->port = port;
+  driver_data->port_term = driver_mk_port(port);
+  return (ErlDrvData)driver_data;
+}
+
+
+static void disksup_stop(ErlDrvData handle) {
+  driver_free((struct driver_data *)handle);
+}
+
+
+static void disksup_async(void *data) {
+  struct async_data *async_data = (struct async_data *)data;
+  async_data->disk_data = NULL;
+  async_data->entries = 0;
+  FILE *file = setmntent("/proc/mounts", "r");
+  struct mntent mntent = {0};
+  char buf[MAXPATHLEN * 4] = {0};
+
+  while (getmntent_r(file, &mntent, buf, sizeof(buf))) {
+    struct statvfs stat = {0};
+
+    if (statvfs(mntent.mnt_dir, &stat))
+      continue;
+    if (!stat.f_files)
+      continue;
+
+    struct disk_data *disk_data = (struct disk_data *)driver_alloc(sizeof(struct disk_data));
+    disk_data->disk_path_len = strlen(mntent.mnt_dir);
+    disk_data->disk_path = (char *)driver_alloc(disk_data->disk_path_len);
+    memcpy(disk_data->disk_path, mntent.mnt_dir, disk_data->disk_path_len);
+    disk_data->disk_size = stat.f_blocks * stat.f_frsize / 1024;
+    fsblkcnt_t used = (stat.f_blocks - stat.f_bfree) * 100;
+    fsblkcnt_t total = stat.f_blocks - stat.f_bfree + stat.f_bavail;
+    disk_data->disk_usage = (used / total) + (used % total > 0);
+
+    disk_data->next = async_data->disk_data;
+    async_data->disk_data = disk_data;
+    async_data->entries++;
+  }
+}
+
+
+static void disksup_output(ErlDrvData handle, char *buff __attribute__((unused)), ErlDrvSizeT bufflen __attribute__((unused))) {
+  struct driver_data *driver_data = (struct driver_data *)handle;
+  struct async_data *async_data = (struct async_data *)driver_alloc(sizeof(struct async_data));
+  driver_async(driver_data->port, NULL, disksup_async, async_data, NULL);
+}
+
+
+static void disksup_ready_async(ErlDrvData handle, ErlDrvThreadData thread_data) {
+  struct driver_data *driver_data = (struct driver_data *)handle;
+  struct async_data *async_data = (struct async_data *)thread_data;
+  struct disk_data *disk_data = async_data->disk_data;
+
+  ErlDrvTermData term[(async_data->entries) * 9 + 7];
+  int i = 0;
+  term[i++] = ERL_DRV_PORT;
+  term[i++] = driver_data->port_term;
+
+  while(disk_data) {
+    term[i++] = ERL_DRV_STRING;
+    term[i++] = (ErlDrvTermData)disk_data->disk_path;
+    term[i++] = disk_data->disk_path_len;
+    term[i++] = ERL_DRV_UINT;
+    term[i++] = disk_data->disk_size;
+    term[i++] = ERL_DRV_INT;
+    term[i++] = disk_data->disk_usage;
+    term[i++] = ERL_DRV_TUPLE;
+    term[i++] = 3;
+    disk_data = disk_data->next;
+  }
+  term[i++] = ERL_DRV_NIL;
+  term[i++] = ERL_DRV_LIST;
+  term[i++] = async_data->entries + 1;
+  term[i++] = ERL_DRV_TUPLE;
+  term[i++] = 2;
+  erl_drv_output_term(driver_data->port_term, term, sizeof(term)/sizeof(ErlDrvTermData));
+
+  disk_data = async_data->disk_data;
+  while(disk_data) {
+    struct disk_data *next_disk_data = disk_data->next;
+    driver_free(disk_data->disk_path);
+    driver_free(disk_data);
+    disk_data = next_disk_data;
+  }
+  driver_free(async_data);
+}
+
+
+ErlDrvEntry disksup_entry = {
+  .init            = NULL,
+  .start           = disksup_start,
+  .stop            = disksup_stop,
+  .output          = disksup_output,
+  .ready_input     = NULL,
+  .ready_output    = NULL,
+  .driver_name     = "disksup",
+  .finish          = NULL,
+  .handle          = NULL,
+  .control         = NULL,
+  .timeout         = NULL,
+  .outputv         = NULL,
+  .ready_async     = disksup_ready_async,
+  .flush           = NULL,
+  .call            = NULL,
+  .event           = NULL,
+  .extended_marker = ERL_DRV_EXTENDED_MARKER,
+  .major_version   = ERL_DRV_EXTENDED_MAJOR_VERSION,
+  .minor_version   = ERL_DRV_EXTENDED_MINOR_VERSION,
+  .driver_flags    = 0,
+  .handle2         = NULL,
+  .process_exit    = NULL,
+  .stop_select     = NULL,
+};
+
+
+DRIVER_INIT(disksup) {
+  return &disksup_entry;
+}

--- a/erlang/os_mon/c_src/memsup.c
+++ b/erlang/os_mon/c_src/memsup.c
@@ -1,0 +1,174 @@
+#include <sys/sysinfo.h>
+#include <erl_driver.h>
+#include "memsup.h"
+
+
+struct driver_data {
+  ErlDrvPort port;
+  ErlDrvTermData port_term;
+};
+
+struct async_data {
+  int type;
+  unsigned long mem_total;
+  unsigned long mem_free;
+  unsigned long mem_buffers;
+  unsigned long mem_shared;
+  unsigned long swap_total;
+  unsigned long swap_free;
+};
+
+
+static ErlDrvData memsup_start(ErlDrvPort port, char *buff __attribute__((unused))) {
+  struct driver_data *driver_data = (struct driver_data *)driver_alloc(sizeof(struct driver_data));
+  driver_data->port = port;
+  driver_data->port_term = driver_mk_port(port);
+  return (ErlDrvData)driver_data;
+}
+
+
+static void memsup_stop(ErlDrvData handle) {
+  driver_free((struct driver_data *)handle);
+}
+
+
+static void memsup_async(void *data) {
+  struct async_data *async_data = (struct async_data *)data;
+  struct sysinfo info = {0};
+  sysinfo(&info);
+  async_data->mem_total   = info.totalram;
+  async_data->mem_free    = info.freeram;
+  async_data->mem_buffers = info.bufferram;
+  async_data->mem_shared  = info.sharedram;
+  async_data->swap_total  = info.totalswap;
+  async_data->swap_free   = info.freeswap;
+}
+
+
+static void memsup_output(ErlDrvData handle, char *buff, ErlDrvSizeT bufflen) {
+  struct driver_data *driver_data = (struct driver_data *)handle;
+
+  if (bufflen == 0)
+    return;
+
+  struct async_data *async_data = (struct async_data *)driver_alloc(sizeof(struct async_data));
+  async_data->type = buff[0];
+  driver_async(driver_data->port, NULL, memsup_async, async_data, NULL);
+}
+
+
+static void memsup_ready_async(ErlDrvData handle, ErlDrvThreadData thread_data) {
+  struct driver_data *driver_data = (struct driver_data *)handle;
+  struct async_data *async_data = (struct async_data *)thread_data;
+  int i;
+
+  switch(async_data->type) {
+  case SHOW_MEM: {
+    ErlDrvTermData term[][6] = {
+      {ERL_DRV_PORT, driver_data->port_term,
+       ERL_DRV_UINT, async_data->mem_total - async_data->mem_free,
+       ERL_DRV_TUPLE, 2},
+      {ERL_DRV_PORT, driver_data->port_term,
+       ERL_DRV_UINT, async_data->mem_total,
+       ERL_DRV_TUPLE, 2}
+    };
+
+    for(i=0;i<2;i++) {
+      erl_drv_output_term(driver_data->port_term, term[i], 6);
+    }
+    break;
+  }
+  case SHOW_SYSTEM_MEM: {
+    ErlDrvTermData term[][6] = {
+      {ERL_DRV_PORT, driver_data->port_term,
+       ERL_DRV_UINT, MEM_TOTAL,
+       ERL_DRV_TUPLE, 2},
+      {ERL_DRV_PORT, driver_data->port_term,
+       ERL_DRV_UINT, async_data->mem_total,
+       ERL_DRV_TUPLE, 2},
+      {ERL_DRV_PORT, driver_data->port_term,
+       ERL_DRV_UINT, MEM_FREE,
+       ERL_DRV_TUPLE, 2},
+      {ERL_DRV_PORT, driver_data->port_term,
+       ERL_DRV_UINT, async_data->mem_free,
+       ERL_DRV_TUPLE, 2},
+      {ERL_DRV_PORT, driver_data->port_term,
+       ERL_DRV_UINT, MEM_BUFFERS,
+       ERL_DRV_TUPLE, 2},
+      {ERL_DRV_PORT, driver_data->port_term,
+       ERL_DRV_UINT, async_data->mem_buffers,
+       ERL_DRV_TUPLE, 2},
+      {ERL_DRV_PORT, driver_data->port_term,
+       ERL_DRV_UINT, MEM_SHARED,
+       ERL_DRV_TUPLE, 2},
+      {ERL_DRV_PORT, driver_data->port_term,
+       ERL_DRV_UINT, async_data->mem_shared,
+       ERL_DRV_TUPLE, 2},
+      {ERL_DRV_PORT, driver_data->port_term,
+       ERL_DRV_UINT, SWAP_TOTAL,
+       ERL_DRV_TUPLE, 2},
+      {ERL_DRV_PORT, driver_data->port_term,
+       ERL_DRV_UINT, async_data->swap_total,
+       ERL_DRV_TUPLE, 2},
+      {ERL_DRV_PORT, driver_data->port_term,
+       ERL_DRV_UINT, SWAP_FREE,
+       ERL_DRV_TUPLE, 2},
+      {ERL_DRV_PORT, driver_data->port_term,
+       ERL_DRV_UINT, async_data->swap_free,
+       ERL_DRV_TUPLE, 2},
+      {ERL_DRV_PORT, driver_data->port_term,
+       ERL_DRV_UINT, MEM_SYSTEM_TOTAL,
+       ERL_DRV_TUPLE, 2},
+      {ERL_DRV_PORT, driver_data->port_term,
+       ERL_DRV_UINT, async_data->mem_total,
+       ERL_DRV_TUPLE, 2},
+    };
+
+    for(i=0;i<14;i++) {
+      erl_drv_output_term(driver_data->port_term, term[i], 6);
+    }
+
+    ErlDrvTermData end_term[] = {
+      ERL_DRV_PORT, driver_data->port_term,
+      ERL_DRV_UINT, SHOW_SYSTEM_MEM_END,
+      ERL_DRV_TUPLE, 2};
+
+    erl_drv_output_term(driver_data->port_term, end_term, 6);
+    break;
+  }
+  default:
+    break;
+  }
+}
+
+
+ErlDrvEntry memsup_entry = {
+  .init            = NULL,
+  .start           = memsup_start,
+  .stop            = memsup_stop,
+  .output          = memsup_output,
+  .ready_input     = NULL,
+  .ready_output    = NULL,
+  .driver_name     = "memsup",
+  .finish          = NULL,
+  .handle          = NULL,
+  .control         = NULL,
+  .timeout         = NULL,
+  .outputv         = NULL,
+  .ready_async     = memsup_ready_async,
+  .flush           = NULL,
+  .call            = NULL,
+  .event           = NULL,
+  .extended_marker = ERL_DRV_EXTENDED_MARKER,
+  .major_version   = ERL_DRV_EXTENDED_MAJOR_VERSION,
+  .minor_version   = ERL_DRV_EXTENDED_MINOR_VERSION,
+  .driver_flags    = 0,
+  .handle2         = NULL,
+  .process_exit    = NULL,
+  .stop_select     = NULL,
+};
+
+
+DRIVER_INIT(memsup) {
+  return &memsup_entry;
+}

--- a/erlang/os_mon/c_src/memsup.h
+++ b/erlang/os_mon/c_src/memsup.h
@@ -1,0 +1,46 @@
+/*
+ * %CopyrightBegin%
+ * 
+ * Copyright Ericsson AB 1998-2009. All Rights Reserved.
+ * 
+ * The contents of this file are subject to the Erlang Public License,
+ * Version 1.1, (the "License"); you may not use this file except in
+ * compliance with the License. You should have received a copy of the
+ * Erlang Public License along with this software. If not, it can be
+ * retrieved online at http://www.erlang.org/.
+ * 
+ * Software distributed under the License is distributed on an "AS IS"
+ * basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See
+ * the License for the specific language governing rights and limitations
+ * under the License.
+ * 
+ * %CopyrightEnd%
+ */
+/*
+ * This header defines the protocol between the erlang 
+ * memsup module and the C module.
+ */
+#ifndef _SYSMEM_H
+#define _SYSMEM_H
+
+/* Simple memory statistics */
+/*IG*/ #define SHOW_MEM 1 
+
+/* Extended memory statistics */
+/*IG*/ #define SHOW_SYSTEM_MEM 2
+
+/* Tags for the extended statistics */
+/*IG*/ #define SHOW_SYSTEM_MEM_END 0
+/*IG*/ #define MEM_SYSTEM_TOTAL 1
+/*IG*/ #define MEM_TOTAL 2
+/*IG*/ #define MEM_FREE 3
+/*IG*/ #define MEM_LARGEST_FREE 4
+/*IG*/ #define MEM_NUMBER_OF_FREE 5
+/*Extension*/
+/*IG*/ #define MEM_BUFFERS 6
+/*IG*/ #define MEM_CACHED 7
+/*IG*/ #define MEM_SHARED 8
+/*IG*/ #define SWAP_TOTAL 9
+/*IG*/ #define SWAP_FREE 10
+
+#endif

--- a/erlang/os_mon/ebin/os_mon.app
+++ b/erlang/os_mon/ebin/os_mon.app
@@ -1,0 +1,35 @@
+%%
+%% %CopyrightBegin%
+%% 
+%% Copyright Ericsson AB 1996-2009. All Rights Reserved.
+%% 
+%% The contents of this file are subject to the Erlang Public License,
+%% Version 1.1, (the "License"); you may not use this file except in
+%% compliance with the License. You should have received a copy of the
+%% Erlang Public License along with this software. If not, it can be
+%% retrieved online at http://www.erlang.org/.
+%% 
+%% Software distributed under the License is distributed on an "AS IS"
+%% basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See
+%% the License for the specific language governing rights and limitations
+%% under the License.
+%% 
+%% %CopyrightEnd%
+%%
+
+{application, os_mon,
+   [{description, "CPO  CXC 138 46"},
+    {vsn, "2.3"},
+    {modules, [os_mon, os_mon_mib, os_sup,
+               disksup, memsup, cpu_sup, os_mon_sysinfo, nteventlog]},
+    {registered, [os_mon_sup, os_mon_sysinfo, disksup, memsup, cpu_sup,
+                  os_sup_server]},
+    {applications, [kernel, stdlib, sasl]},
+    {env, [{start_cpu_sup, false},
+	   {start_disksup, true},
+	   {start_memsup, true},
+	   {start_os_sup, false}]},
+    {mod, {os_mon, []}},
+    {runtime_dependencies, ["stdlib-2.0","snmp-4.25.1","sasl-2.4",
+			    "otp_mibs-1.0.9","mnesia-4.12","kernel-3.0",
+			    "erts-6.0"]}]}.

--- a/erlang/os_mon/include/memsup.hrl
+++ b/erlang/os_mon/include/memsup.hrl
@@ -1,0 +1,43 @@
+%%
+%% %CopyrightBegin%
+%% 
+%% Copyright Ericsson AB 1998-2009. All Rights Reserved.
+%% 
+%% The contents of this file are subject to the Erlang Public License,
+%% Version 1.1, (the "License"); you may not use this file except in
+%% compliance with the License. You should have received a copy of the
+%% Erlang Public License along with this software. If not, it can be
+%% retrieved online at http://www.erlang.org/.
+%% 
+%% Software distributed under the License is distributed on an "AS IS"
+%% basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See
+%% the License for the specific language governing rights and limitations
+%% under the License.
+%% 
+%% %CopyrightEnd%
+%%
+-ifndef(_memsup_hrl).
+-define(_memsup_hrl,true).
+%%% This file has to be kept consistent with ../c_src/memsup.h. 
+%%% Keep consistence manually.
+
+%% Defines
+
+-define( SHOW_MEM , 1 ).
+-define( SHOW_SYSTEM_MEM , 2 ).
+-define( SHOW_SYSTEM_MEM_END , 8#0 ).
+%% tags for extended statistics
+-define( MEM_SYSTEM_TOTAL , 1 ).
+-define( MEM_TOTAL , 2 ).
+-define( MEM_FREE , 3 ).
+-define( MEM_LARGEST_FREE , 4 ).
+-define( MEM_NUMBER_OF_FREE , 5 ).
+%% extensions 
+-define( MEM_BUFFERS , 6 ).
+-define( MEM_CACHED , 7 ).
+-define( MEM_SHARED , 8 ).
+-define( SWAP_TOTAL , 9 ).
+-define( SWAP_FREE , 10 ).
+
+-endif.
+


### PR DESCRIPTION
memsup and disksup spawn external process to collect data. Now, they have
been rewritten as port drivers.

Signed-off-by: bhuztez <bhuztez@gmail.com>

try in Erlang Shell

```
1> application:start(sasl).
2> application:start(os_mon).
3> memsup:get_memory_data().
4> memsup:get_system_memory_data().
5> disksup:get_disk_data().
```