### PR TITLE
erlang: add erlexec wrapper

### DIFF
--- a/erlang/Capstanfile
+++ b/erlang/Capstanfile
@@ -1,2 +1,2 @@
 base: cloudius/osv-base
-cmdline: --env=BINDIR=/usr/lib64/erlang/erts-6.2/bin /usr/lib64/erlang/erts-6.2/bin/beam.smp -K true -- -root /usr/lib64/erlang -progname erl -- -home / --
+cmdline: /usr/lib64/erlang.so -env HOME / /etc/erlang/vm.args /etc/default/erlang/vm.args

--- a/erlang/Makefile
+++ b/erlang/Makefile
@@ -1,9 +1,10 @@
 .PHONY: all
 
 OTP_VERSION=17.3
+ERTS_VERSION=6.2
 
-all: install
-module: install
+all: install erlang.so
+module: install erlang.so
 
 otp_src_$(OTP_VERSION).tar.gz:
 	wget -O "$@.temp" "http://www.erlang.org/download/otp_src_$(OTP_VERSION).tar.gz"
@@ -16,7 +17,7 @@ otp_src_$(OTP_VERSION): otp_src_$(OTP_VERSION).tar.gz
 	patch -b -p0 < epmd.patch
 
 configure: otp_src_$(OTP_VERSION)
-	cd otp_src_$(OTP_VERSION); export ERL_TOP=$(CURDIR)/otp_src_$(OTP_VERSION) CFLAGS=-fpie LDFLAGS=-pie; ./configure -prefix=/usr --libdir=/usr/lib64 --disable-hipe --without-hipe --without-odbc --enable-builtin-zlib --without-termcap --without-wx --without-erl_interface --without-javac --without-jinterface
+	cd otp_src_$(OTP_VERSION); export ERL_TOP=$(CURDIR)/otp_src_$(OTP_VERSION) CFLAGS=-fpie LDFLAGS="-pie -rdynamic"; ./configure -prefix=/usr --libdir=/usr/lib64 --disable-hipe --without-hipe --without-odbc --enable-builtin-zlib --without-termcap --without-wx --without-erl_interface --without-javac --without-jinterface
 
 compile: configure
 	mkdir -p ROOTFS
@@ -26,7 +27,10 @@ install: compile
 	cd otp_src_$(OTP_VERSION); export ERL_TOP=$(CURDIR)/otp_src_$(OTP_VERSION) DESTDIR=$(CURDIR)/ROOTFS; make install
 	find ROOTFS -name '*.so' | xargs -I {} ldd {} | grep -Po '(?<=> )/[^ ]+' | sort | uniq | grep -Pv 'lib(c|dl|m|util|rt|pthread).so' | xargs -I {} install -D -T {} ROOTFS{}
 
+erlang.so: erlang.c
+	$(CC) -shared -rdynamic -fPIC -o erlang.so -std=gnu99 -DERTS_VERSION=$(ERTS_VERSION) erlang.c
+
 clean:
 	-rm -rf ROOTFS
 	-rm -rf otp_src_$(OTP_VERSION)
-	-rm -f otp_src_$(OTP_VERSION).tar.gz otp_src_$(OTP_VERSION).tar.gz.temp
+	-rm -f otp_src_$(OTP_VERSION).tar.gz otp_src_$(OTP_VERSION).tar.gz.temp erlang.so

--- a/erlang/README
+++ b/erlang/README
@@ -1,5 +1,27 @@
 Erlang running on OSv. still a work in progress.
 
-make
-capstan build -v
-capstan run
+build image with Capstan
+
+$ make
+$ capstan build -v
+$ capstan run
+
+
+erlexec wrapper
+
+usage: /usr/lib64/erlang.so [-env NAME VALUE] ARGS_FILE FALLBACK_ARGS_FILE
+
+is equivalent to
+
+$ export NAME=VALUE
+$ rm /etc/beam.args
+$ mv ARGS_FILE /etc/beam.args
+$ ln FALLBACK_ARGS_FILE /etc/beam.args
+$ erlexec -args_file /etc/beam.args
+
+ARGS_FILE: path to args_file provided by cloud-init.
+
+FALLBACK_ARGS_FILE: path to args_file existed in the image.
+
+some environment variables, e.g. HOME, must be set before running
+erlexec. you may set them with -env option.

--- a/erlang/epmd.patch
+++ b/erlang/epmd.patch
@@ -1,27 +1,6 @@
-diff -up otp_src_17.3/erts/epmd/src/Makefile.in.orig otp_src_17.3/erts/epmd/src/Makefile.in
---- otp_src_17.3/erts/epmd/src/Makefile.in.orig	2015-05-12 08:55:13.512064200 +0800
-+++ otp_src_17.3/erts/epmd/src/Makefile.in	2015-05-12 08:56:02.924734358 +0800
-@@ -87,7 +87,7 @@ else
- LIBS    = @LIBS@ @SYSTEMD_DAEMON_LIBS@ $(ERTS_INTERNAL_LIBS)
- endif
- LDFLAGS = @LDFLAGS@
--
-+DEXPORT = @DEXPORT@
- 
- 
- # ----------------------------------------------------
-@@ -151,7 +151,7 @@ $(BINDIR)/$(EPMD): $(EPMD_OBJS) $(ERTS_L
- 	$(call build-ose-load-module, $@, $(EPMD_OBJS) $(OSE_LM_OBJS), $(LIBS), $(EPMD_LMCONF))
- else
- $(BINDIR)/$(EPMD): $(EPMD_OBJS) $(ERTS_LIB)
--	$(ld_verbose)$(PURIFY) $(LD) $(LDFLAGS) -o $@ $(EPMD_OBJS) $(LIBS)
-+	$(ld_verbose)$(PURIFY) $(LD) $(LDFLAGS) $(DEXPORT) -o $@ $(EPMD_OBJS) $(LIBS)
- endif
- 
- $(OBJDIR)/%.o: %.c epmd.h epmd_int.h
 diff -up otp_src_17.3/erts/etc/common/erlexec.c.orig otp_src_17.3/erts/etc/common/erlexec.c
---- otp_src_17.3/erts/etc/common/erlexec.c.orig	2015-05-11 19:47:37.053496386 +0800
-+++ otp_src_17.3/erts/etc/common/erlexec.c	2015-05-12 14:12:05.198659854 +0800
+--- otp_src_17.3/erts/etc/common/erlexec.c.orig	2014-09-17 03:10:57.000000000 +0800
++++ otp_src_17.3/erts/etc/common/erlexec.c	2015-05-12 14:30:54.276803481 +0800
 @@ -30,6 +30,8 @@
  #include "erl_driver.h"
  #include <stdlib.h>
@@ -163,8 +142,8 @@ diff -up otp_src_17.3/erts/etc/common/erlexec.c.orig otp_src_17.3/erts/etc/commo
        exit(1);
      }
 diff -up otp_src_17.3/erts/etc/common/Makefile.in.orig otp_src_17.3/erts/etc/common/Makefile.in
---- otp_src_17.3/erts/etc/common/Makefile.in.orig	2015-05-11 20:02:59.263209893 +0800
-+++ otp_src_17.3/erts/etc/common/Makefile.in	2015-05-11 20:03:32.620571829 +0800
+--- otp_src_17.3/erts/etc/common/Makefile.in.orig	2014-09-17 03:10:57.000000000 +0800
++++ otp_src_17.3/erts/etc/common/Makefile.in	2015-05-12 14:30:54.277803433 +0800
 @@ -447,7 +447,7 @@ $(OBJDIR)/safe_string.o: ../common/safe_
  
  ifneq ($(TARGET),win32)

--- a/erlang/erlang.c
+++ b/erlang/erlang.c
@@ -1,0 +1,69 @@
+#include <stdio.h>
+#include <stdbool.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <dlfcn.h>
+#include <limits.h>
+
+#define ARGS_FILE "/etc/beam.args"
+#define STR_HELPER(x) #x
+#define STR(x) STR_HELPER(x)
+
+#define ROOTDIR "/usr/lib64/erlang"
+#define BINDIR ROOTDIR "/erts-" STR(ERTS_VERSION) "/bin"
+
+int main(int argc, char **argv){
+  setenv("ROOTDIR", ROOTDIR, false);
+  setenv("BINDIR", BINDIR, false);
+
+  while(--argc) {
+    argv++;
+
+    if (strcmp(argv[0], "-env"))
+        break;
+
+    argc -= 2;
+    if (argc < 0) {
+      fprintf(stderr, "too few argument for env\n");
+      exit(1);
+    }
+
+    setenv(argv[1], argv[2], true);
+    argv += 2;
+  }
+
+  if (argc != 2) {
+    fprintf(stderr, "exactly two arguments required\n");
+    exit(1);
+  }
+
+  char *args_file = argv[0];
+  char *fallback = argv[1];
+
+  remove(ARGS_FILE);
+  rename(args_file, ARGS_FILE);
+  link(fallback, ARGS_FILE);
+
+  char path[PATH_MAX] = {0};
+  snprintf(path, PATH_MAX, "%s/erlexec", BINDIR);
+
+  void *elf_handle = dlopen(path, RTLD_LAZY);
+
+  if (!elf_handle)
+    goto err;
+
+  int (*mainfun)(int, char **) = (int (*)(int, char **)) dlsym(elf_handle, "main");
+
+  char *erl_argv[] = {"erlexec", "-args_file", ARGS_FILE, NULL};
+  int result = (mainfun)?mainfun(3, erl_argv):1;
+  dlclose(elf_handle);
+
+  if(!mainfun)
+    goto err;
+
+  return result;
+err:
+  fprintf(stderr, "Error spawning erlexec\n");
+  return 1;
+}

--- a/erlang/etc/default/erlang/vm.args
+++ b/erlang/etc/default/erlang/vm.args
@@ -1,0 +1,2 @@
++K true
+-name foo@127.0.0.1

--- a/erlang/module.py
+++ b/erlang/module.py
@@ -1,3 +1,3 @@
 from osv.modules import api
 
-default = api.run(cmdline="--env=BINDIR=/usr/lib64/erlang/erts-6.2/bin --env=HOME=/ /usr/lib64/erlang/erts-6.2/bin/erlexec +K true -name foo@127.0.0.1")
+default = api.run(cmdline="/usr/lib64/erlang.so -env HOME / /etc/erlang/vm.args /etc/default/erlang/vm.args")

--- a/erlang/usr.manifest
+++ b/erlang/usr.manifest
@@ -1,1 +1,3 @@
 /**: ${MODULE_DIR}/ROOTFS/**
+/usr/lib64/erlang.so: ${MODULE_DIR}/erlang.so
+/etc/**: ${MODULE_DIR}/etc/**


### PR DESCRIPTION
the wrapper will use args_file provided by ec2 instance user data, if it
exists. Otherwise it will use the default args_file in the image.

this commit also add -rdynamic to LDFLAGS to ensure that the main symbol
could be found on executables.