### PR TITLE
Add missing libgmp and libcrypt

### DIFF
--- a/ruby/Makefile
+++ b/ruby/Makefile
@@ -63,6 +63,8 @@ usr.manifest: ruby.so upstream/bundler upstream/cert.pem
 	echo '/usr/local/ssl/cert.pem: $${MODULE_DIR}/upstream/cert.pem' >> usr.manifest
 	find upstream/ruby/.ext/x86_64-linux/ -name '*.so' -exec ldd {} \;|awk '{print $$1,":",$$3}'|grep "/lib"|grep -v "ld-linux"|grep -v "libc.so"|grep -v "libresolv.so.2"|grep -v "libpthread.so"|grep -v "libdl.so"|grep -v "libm.so"|sort|uniq|sed -e "s/ //" \
 		>> usr.manifest
+	find upstream/ruby/ -name "libruby.so" -exec ldd {} \;|awk '{print $$1,":",$$3}' |grep "/lib"|grep -v "ld-linux"|grep -v "libc.so"|grep -v "libresolv.so.2"|grep -v "libpthread.so"|grep -v "libdl.so"|grep -v "libm.so"|sort|uniq|sed -e "s/ //" \
+		>> usr.manifest
 	: > bootfs.manifest
 
 ROOTFS: module
@@ -77,6 +79,7 @@ ROOTFS: module
 	cp -a ./upstream/ruby/.ext/x86_64-linux/* ./ROOTFS/usr/lib/ruby/2.2.0/x86_64-linux/
 	cp ./upstream/cert.pem ./ROOTFS/usr/local/ssl/cert.pem
 	find upstream/ruby/.ext/x86_64-linux/ -name '*.so' -exec ldd {} \;|awk '{print "cp",$$3,"./ROOTFS/"}'|grep "/lib"|grep -v "ld-linux"|grep -v "libc.so"|grep -v "libpthread.so"|grep -v "libdl.so"|grep -v "libm.so"|grep -v "libruby.so"|sort|uniq > tmp.sh
+	find upstream/ruby/ -name "libruby.so" -exec ldd {} \;|awk '{print $$1,":",$$3}' |grep "/lib"|grep -v "ld-linux"|grep -v "libc.so"|grep -v "libresolv.so.2"|grep -v "libpthread.so"|grep -v "libdl.so"|grep -v "libm.so"|sort|uniq|sed -e "s/ //" >> tmp.sh
 	sh tmp.sh
 	rm tmp.sh
 


### PR DESCRIPTION
libruby.so depends `libgmp.so` and `lincrypt.so`.
But, previous searching implementation could not find libgmp.so and libcrypt.so.

So, I modified Makefile as suggested: https://github.com/cloudius-systems/osv-apps/issues/22#issuecomment-109747782.

I've confirmed that Ruby works well after applying this change.
But I think that this patch is ad hoc fixing....

Signed-off-by: Hiroshi Hatake <cosmo0920.oucc@gmail.com>