### PR TITLE
jruby-sinatra-example: Update jruby version to 9.0.0.0

### DIFF
--- a/jruby-sinatra-example/GET
+++ b/jruby-sinatra-example/GET
@@ -1,5 +1,5 @@
 #!/bin/sh
-VERSION=1.7.16.1
+VERSION=9.0.0.0
 wget http://jruby.org.s3.amazonaws.com/downloads/$VERSION/jruby-complete-$VERSION.jar
 mv jruby-complete-$VERSION.jar jruby-complete.jar
 mkdir gemjar


### PR DESCRIPTION
JRuby 9.0.0.0 has been released!
Let's update jruby!

Signed-off-by: Hiroshi Hatake <cosmo0920.oucc@gmail.com>