### PR TITLE
Initial port of Cado 1.107 for OSv.

### DIFF
--- a/cado/.gitignore
+++ b/cado/.gitignore
@@ -1,0 +1,17 @@
+ROOTFS*
+TODO.txt
+.vimlist
+perl
+experiments
+osvbuild.sh
+/xx*
+/yy*
+/zz*
+/foo*
+/junk*
+~*
+*.swp
+*.tar.bz2
+*.tgz
+/toc.*
+/tmp

--- a/cado/Capstanfile
+++ b/cado/Capstanfile
@@ -1,0 +1,10 @@
+base: perl-base
+
+cmdline: >
+    --env=PATH=/osv/bin:/cado/bin/cmn
+    --env=PERL_LIBPATH=/cado/lib/cmn
+    /osv/bin/perl
+    /cado/bin/cmn/cado -V
+
+#this will build the installation image under ./ROOTFS, which is automatically copied to the VM disk image by capstan:
+build: make install

--- a/cado/Makefile
+++ b/cado/Makefile
@@ -1,0 +1,35 @@
+.DEFAULT_GOAL := install
+
+_CADO_VERS := 1_107
+CADO_VERS  != echo 1_107 | sed -e 's/_/./'
+CADOSRC_DIST  := cado_linux_$(_CADO_VERS).tgz
+WGET_URL      := http://iweb.dl.sourceforge.net/project/cado/v$(CADO_VERS)/$(CADOSRC_DIST)
+
+install: $(CADOSRC_DIST) ROOTFS/cado
+
+$(CADOSRC_DIST):
+	#echo CADO_VERS=$(CADO_VERS) CADOSRC_DIST=$(CADOSRC_DIST)
+	wget $(WGET_URL)
+
+ROOTFS/cado:
+	mkdir -p ROOTFS
+	tar xf $(CADOSRC_DIST)
+	mv cado_linux_$(_CADO_VERS) ROOTFS/cado
+	#punt on compiled crc for now since we can't fork:
+	rm -rf ROOTFS/cado/bin/linux
+	#temporary fix for sp.pl:
+	chmod 0644 ROOTFS/cado/lib/cmn/sp.pl
+	patch -i patch.sp.pl ROOTFS/cado/lib/cmn/sp.pl
+	#remove shell exec header for cado:
+	chmod 0644 ROOTFS/cado/bin/cmn/cado
+	sed -ne '2,$$p' ROOTFS/cado/bin/cmn/cado > ROOTFS/cado/bin/cmn/cado.new
+	mv ROOTFS/cado/bin/cmn/cado.new ROOTFS/cado/bin/cmn/cado 
+
+clean:
+	rm -rf ROOTFS
+
+deepclean: clean
+	rm -f $(CADOSRC_DIST)
+
+# for scripts/build
+module: install

--- a/cado/README.md
+++ b/cado/README.md
@@ -1,0 +1,49 @@
+# Cado - a code-generation language based on Perl.
+This is a port of Cado for OSv.
+
+Cado is a simple, general-purpose code-generation language.  The Cado interpreter is ideal for generating source code from rich templates, or creating tool-chains for executing and documenting complex, multi-step transformations.
+
+The distribution contains a rich set of templates and libraries for generating Java, xml, html, [Maven](http://maven.apache.org) projects, refactoring shell scripts, and more.
+
+There is also a new set of operators for interacting with VMware ESXi hypervisors or vCenter servers, based on the venerable [VMware Perl SDK](https://developercenter.vmware.com/web/sdk/55/vsphere-perl).
+
+## Prerequisites
+As of this writing, you must build the perl-base image before you can create the Cado image.  (Once Perl has been accepted in the public [Capstan](https://github.com/cloudius-systems/capstan) repository, this will no longer be necessary.)
+
+See osv-apps/perl for more information.
+
+## Porting Changes
+There were only a couple of small changes that were necessary:
+
+- eliminated a `system()` call in sp.pl, which was only used to set the local timezone.  Now uses the perl `POSIX` package instead.
+- eliminated the shell start-up line from the cado command script.
+
+Both edits are done from the `Makefile` at present.
+
+##How to Build
+I use [Capstan](https://github.com/cloudius-systems/capstan) to build.  Since the base is pure perl, you can build the cado base image on any system that supports QEMU.  For example, to build on Mac OS X, you can use [Macports](https://www.macports.org) to install QEMU, install Capstan, and then tell capstan where to find the QEMU binary:
+
+    $ sudo port install qemu
+    $ export CAPSTAN_QEMU_PATH=/opt/local/bin/qemu-system-x86_64
+    $ capstan build ...
+
+There is a small `build.sh` script to illustrate the top-level build commands for different hypervisors.
+
+##How to Run
+You can use Capstan to run.  Here is how it looks running under VMware Fusion 7.1.1:
+
+    $ capstan run -p vmw -i cado-base cadobase00
+    Created instance: cadobase00
+    OSv v0.22
+    eth0: 192.168.98.172
+    cado: Version 1.107, 18-Nov-2014.
+
+For the base image, cado just prints its version and exits.
+
+## The Cado Open Source Project
+The cado project is hosted on github and sourceforge:
+
+* https://github.com/russt/cado
+* http://sourceforge.net/projects/cado
+
+Distribution tarballs can be downloaded from the sourceforge project.

--- a/cado/build.sh
+++ b/cado/build.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+#
+#build.sh - build images for various hypervisor targets.
+#
+
+verbose=-v
+verbose=
+
+imagename=cado-base
+hypervisors="qemu vbox vmw gce"
+hypervisors="vmw"
+
+for target in $hypervisors 
+do
+    echo capstan build -p $target $verbose $imagename
+    capstan build -p $target $verbose $imagename
+done

--- a/cado/module.py
+++ b/cado/module.py
@@ -1,0 +1,11 @@
+from osv.modules import api
+
+api.require('cado')
+
+default = api.run(
+    '--cwd=/cado '
+    '--env=PATH=/osv/bin:/cado/bin/cmn '
+    '--env=PERL_LIBPATH=/cado/lib/cmn '
+    '/osv/bin/perl '
+    '/cado/bin/cmn/cado -V'
+)

--- a/cado/patch.sp.pl
+++ b/cado/patch.sp.pl
@@ -1,0 +1,62 @@
+*** sp.pl.old	Sun Aug  9 12:58:01 2015
+--- sp.pl.new	Sun Aug  9 12:59:08 2015
+***************
+*** 44,65 ****
+  	$VERBOSE = 0;
+  
+  	$RM_FLAG = "";  # used for RunUsePath
+  
+  
+! 	$TIMEZONE = "TZ_UNDEF";
+! 
+! 	######
+! 	# note:  TZ on solaris is set to point to a file in /usr/share/lib/zoneinfo.
+! 	# e.g:  /usr/share/lib/zoneinfo/US/Pacific
+! 	# date +%Z will return the old form, such as PST or PDT.
+! 	######
+! 	my($tmp) = `sh -c "date +%Z"`;
+! 	$status = ($? >> 8);
+! 	if ($status == 0){
+! 		chomp $tmp;
+! 		$TIMEZONE = $tmp;
+! 	}
+! 
+  }
+  
+  sub check_env
+--- 44,58 ----
+  	$VERBOSE = 0;
+  
+  	$RM_FLAG = "";  # used for RunUsePath
++ }
+  
++ use POSIX;
++ my $TIMEZONE = undef;
+  
+! sub init_timezone
+! {
+! 	#we only initialize if we need to.
+! 	$TIMEZONE = strftime("%Z", localtime()), "\n" unless($TIMEZONE);
+  }
+  
+  sub check_env
+***************
+*** 212,217 ****
+--- 205,211 ----
+  sub GetDateStr
+  	# Return the current date as if you ran `date`
+  {
++ 	&init_timezone();
+  	($sec,$min,$hour,$mday,$mon,$year,$wday,$yday,$isdt) = localtime();
+  	$date = (Sun,Mon,Tue,Wed,Thu,Fri,Sat)[$wday];
+  	$date .= " ";
+***************
+*** 225,230 ****
+--- 219,225 ----
+  sub GetDateStrFromUnixTime
+  {
+  	local($tme) = @_;
++ 	&init_timezone();
+  	($sec,$min,$hour,$mday,$mon,$year,$wday,$yday,$isdt) = localtime($tme);
+  	$date = (Sun,Mon,Tue,Wed,Thu,Fri,Sat)[$wday];
+  	$date .= " ";

--- a/cado/usr.manifest
+++ b/cado/usr.manifest
@@ -1,0 +1,1 @@
+/**: ${MODULE_DIR}/ROOTFS/**


### PR DESCRIPTION
Requires perl-base image.
Note:  I added module.py and usr.manifest, but they are untested.
More details about the port in README.md.