### PR TITLE
mysql: Added spaces in the manifest to fix errors in the build scripts.

### DIFF
--- a/mysql/GET
+++ b/mysql/GET
@@ -40,9 +40,9 @@ $(cat CMakeFiles/mysqld.dir/link.txt) -shared
 cd $BASEDIR
 
 echo "
-/etc/**:${ROOTDIR}/etc/**
-/usr/share/**:${ROOTDIR}/usr/share/**
-/usr/lib/**:${ROOTDIR}/usr/lib/**
-/usr/data/**:${ROOTDIR}/usr/data/**
-/usr/bin/mysqld:${BUILDDIR}/sql/mysqld
+/etc/**: ${ROOTDIR}/etc/**
+/usr/share/**: ${ROOTDIR}/usr/share/**
+/usr/lib/**: ${ROOTDIR}/usr/lib/**
+/usr/data/**: ${ROOTDIR}/usr/data/**
+/usr/bin/mysqld: ${BUILDDIR}/sql/mysqld
 " > usr.manifest


### PR DESCRIPTION
The MySQL image does not build - it fails with an out-of-bound error in the build script. The reason is that it cannot split the lines in the manifest into two parts.

This change fixes the problem by adding additional spaces after the colons.