### PR TITLE
the exe name is now libhttpserver-api.so

### DIFF
--- a/httpserver-html5-cli/module.py
+++ b/httpserver-html5-cli/module.py
@@ -13,7 +13,7 @@ api.require('httpserver-api')
 
 # httpserver will run regardless of an explicit command line
 # passed with "run.py -e".
-_exe = '/libhttpserver.so'
+_exe = '/libhttpserver-api.so'
 daemon = api.run_on_init(_exe + ' &!')
 
 fg = api.run(_exe)


### PR DESCRIPTION
Fix https://github.com/cloudius-systems/osv-apps/issues/59