### PR TITLE
Add a way to include extra python3 modules

### DIFF
--- a/python3x/GET
+++ b/python3x/GET
@@ -8,6 +8,8 @@ PYTHON_PREFIX_DIR=`python3 -c 'import sys; print(sys.prefix)'`
 PYTHON_MAJOR_VERSION=`python3 -c 'import sys; print(sys.version_info.major)'`
 PYTHON_MINOR_VERSION=`python3 -c 'import sys; print(sys.version_info.minor)'`
 PYTHON_VERSION="${PYTHON_MAJOR_VERSION}.${PYTHON_MINOR_VERSION}"
+PYTHON_MODULES="" #put additional modules here. Include their dependencies. Example: "django mysql mysql.connector"
+
 
 install_shlibs() {
 SHLIBS=""
@@ -39,6 +41,13 @@ for dir in ${PYTHON_PREFIX_DIR}/lib*/python${PYTHON_VERSION}/
 do
     rsync -a "$dir" $ROOTFS/lib/python${PYTHON_VERSION}/ --safe-links --exclude test --exclude unittest \
     --exclude '*.pyc' --exclude '*.pyo' --exclude '*.egg-info' --exclude 'site-packages' --exclude 'dist-packages'
+done
+
+for i in ${PYTHON_MODULES}
+do
+    rsync -a "$(python3 -c "import sys; module = sys.argv[1]; exec('import ' + module); print(eval(module + '.__file__')) if str(eval(module + '.__file__').split('/')[-1]) != '__init__.py' else print(eval(module + '.__path__[0]'))" $i)" \
+    $ROOTFS/lib/python${PYTHON_VERSION}/ --safe-links --exclude test --exclude unittest \
+    --exclude '*.pyc' --exclude '*.pyo' --exclude '*.egg-info'
 done
 
 SHLIBS_COUNT4=`install_shlibs`

--- a/python3x/GET
+++ b/python3x/GET
@@ -27,44 +27,31 @@ ldd $SHLIBS | grep -Po '(?<=> )/[^ ]+' | sort | uniq | grep -Pv 'lib(c|gcc|dl|m|
 echo "$SHLIBS_COUNT"
 }
 
-get_dependencies() {
-python3 - <<'EOF' $1
+get_paths() {
+python3 - <<'EOF' "$1"
 import sys
 
-#get a dict of modules imported at the start
-default_modules = sys.modules.copy()
+unique_paths = set([])
 
 #import all additional modules
-for mod in sys.argv[1].split(" "):
-  exec('import ' + mod)
+for mod in sys.argv[1].split():
+  try:
+    exec('import ' + mod)
+    if str(eval(mod + '.__file__')[-12:]) != '/__init__.py':
+      unique_paths.add(eval(mod + '.__file__'))
+    else:
+      unique_paths.add(eval(mod + '.__path__[0]'))
 
-unique_paths = set()
-
-def path_exploration(l_modules):
-  for mo in l_modules:
-    exec('import ' + mo)
-#for submodules(x.y), copy the top level module(x)
-    l_mod = mo.split('.')[0]
-
-#real modules have file. Some modules have __path__, and their file is __init__.py
-    try:
-      if str(eval(l_mod + '.__file__').split('/')[-1]) != '__init__.py':
-        if eval(l_mod + '.__file__')[-3:] not in ['.so', 'in>']:  #skip .so and <stdin>
-          unique_paths.add(eval(l_mod + '.__file__') + ' ')
-      else:
-        unique_paths.add(str(eval(l_mod + '.__path__[0]')) + '/ ')
-    except NameError:  #module not imported. Try to import
-      path_exploration(set(l_mod))
-    except AttributeError:
-      pass  #built-in modules don't have __file__
-
-modules = set(sys.modules.keys()).difference(set(default_modules.keys()))
-path_exploration(modules)
+  except NameError:  #module not imported. Try to import
+    raise Exception("You misspelled the module name")
+  except AttributeError:
+    pass  #built-in modules don't have __file__
 
 print(" ".join(unique_paths))
 
 EOF
 }
+
 
 main() {
 mkdir -p build/
@@ -82,7 +69,7 @@ do
     --exclude '*.pyc' --exclude '*.pyo' --exclude '*.egg-info' --exclude 'site-packages' --exclude 'dist-packages'
 done
 
-for i in $(get_dependencies "${PYTHON_MODULES}")
+for i in $(get_paths "${PYTHON_MODULES}")
 do
     rsync -a "$i" $ROOTFS/lib/python${PYTHON_VERSION}/ --safe-links \
     --exclude '*.pyc' --exclude '*.pyo' --exclude '*.egg-info'

--- a/python3x/GET
+++ b/python3x/GET
@@ -8,7 +8,7 @@ PYTHON_PREFIX_DIR=`python3 -c 'import sys; print(sys.prefix)'`
 PYTHON_MAJOR_VERSION=`python3 -c 'import sys; print(sys.version_info.major)'`
 PYTHON_MINOR_VERSION=`python3 -c 'import sys; print(sys.version_info.minor)'`
 PYTHON_VERSION="${PYTHON_MAJOR_VERSION}.${PYTHON_MINOR_VERSION}"
-PYTHON_MODULES="" #put additional modules here. Include their dependencies. Example: "django mysql mysql.connector"
+PYTHON_MODULES="" #put additional modules here. Example: "django mysql mysql.connector"
 
 
 install_shlibs() {
@@ -27,6 +27,45 @@ ldd $SHLIBS | grep -Po '(?<=> )/[^ ]+' | sort | uniq | grep -Pv 'lib(c|gcc|dl|m|
 echo "$SHLIBS_COUNT"
 }
 
+get_dependencies() {
+python3 - <<'EOF' $1
+import sys
+
+#get a dict of modules imported at the start
+default_modules = sys.modules.copy()
+
+#import all additional modules
+for mod in sys.argv[1].split(" "):
+  exec('import ' + mod)
+
+unique_paths = set()
+
+def path_exploration(l_modules):
+  for mo in l_modules:
+    exec('import ' + mo)
+#for submodules(x.y), copy the top level module(x)
+    l_mod = mo.split('.')[0]
+
+#real modules have file. Some modules have __path__, and their file is __init__.py
+    try:
+      if str(eval(l_mod + '.__file__').split('/')[-1]) != '__init__.py':
+        if eval(l_mod + '.__file__')[-3:] not in ['.so', 'in>']:  #skip .so and <stdin>
+          unique_paths.add(eval(l_mod + '.__file__') + ' ')
+      else:
+        unique_paths.add(str(eval(l_mod + '.__path__[0]')) + '/ ')
+    except NameError:  #module not imported. Try to import
+      path_exploration(set(l_mod))
+    except AttributeError:
+      pass  #built-in modules don't have __file__
+
+modules = set(sys.modules.keys()).difference(set(default_modules.keys()))
+path_exploration(modules)
+
+print(" ".join(unique_paths))
+
+EOF
+}
+
 main() {
 mkdir -p build/
 gcc -o build/python.so python.c -fPIC -shared -lpython${PYTHON_VERSION}m
@@ -43,10 +82,9 @@ do
     --exclude '*.pyc' --exclude '*.pyo' --exclude '*.egg-info' --exclude 'site-packages' --exclude 'dist-packages'
 done
 
-for i in ${PYTHON_MODULES}
+for i in $(get_dependencies "${PYTHON_MODULES}")
 do
-    rsync -a "$(python3 -c "import sys; module = sys.argv[1]; exec('import ' + module); print(eval(module + '.__file__')) if str(eval(module + '.__file__').split('/')[-1]) != '__init__.py' else print(eval(module + '.__path__[0]'))" $i)" \
-    $ROOTFS/lib/python${PYTHON_VERSION}/ --safe-links --exclude test --exclude unittest \
+    rsync -a "$i" $ROOTFS/lib/python${PYTHON_VERSION}/ --safe-links \
     --exclude '*.pyc' --exclude '*.pyo' --exclude '*.egg-info'
 done
 

--- a/python3x/README
+++ b/python3x/README
@@ -9,9 +9,11 @@ sudo dnf install python3-devel   # On Fedora
 
 The python home directory is assumed to be installed under
 <sys.prefix>/lib/python<sys.version_info.major>.<sys.version_info.minor>/
-where sys is Python package this script reads the sys.* values from. Please
-note that any extra modules found under site-packages or dist-packages
-directories are filtered out from the image.
+where sys is Python package this script reads the sys.* values from.
+
+Please note that any extra modules found under site-packages or dist-packages
+directories are filtered out from the image. You can add extra modules by editing
+the PYTHON_MODULES variable in the GET script.
 
 Example usage:
 


### PR DESCRIPTION
Add PYTHON_MODULES as a variable in GET for specifying non-default modules to include in the unikernel. It doesn't include a nice way to expose this to the user(as a parameter taken by GET for example), but it makes it easier to deploy python3 applications on OSv.

This patch requires a user to manually resolve dependencies, as parsing `python3 -m pip show` output for `Requires: ` only works for packages installed through pip(wouldn't work for packages installed from distro's package managers) and doesn't work for packages that require modules filtered from default modules(for example, numpy requires unittest - a default python module filtered in line 42.