### PR TITLE
Ignore more build artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,14 @@
+# Directories storing files downloaded or collected from the OS
 upstream
 src
 ROOTFS
 install
+
+# Downloaded compressed archives
+*.tar.gz
+
+# Terminal settings from the host
+unknown-term/terminfo
+
+# Unpacked mysql releases
+mysql/mysql-*


### PR DESCRIPTION
Ignore compressed archives, terminal settings and unpacked mysql source code.

If you'd rather split that into directory specific .gitignores, I can do that too