### PR TITLE
Fix sqlite in python3

### DIFF
--- a/python3x/GET
+++ b/python3x/GET
@@ -55,6 +55,9 @@ then
 	echo "ERROR some libraries required by python might be missing"
 	exit 1
 fi
+
+#replace sqlite with a non-MREMAP version
+rsync -a $BASEDIR/../sqlite/libsqlite3.so.0 $ROOTFS/usr/lib/libsqlite3.so.0
 }
 
 main

--- a/python3x/GET
+++ b/python3x/GET
@@ -57,7 +57,7 @@ then
 fi
 
 #replace sqlite with a non-MREMAP version
-rsync -a $BASEDIR/../sqlite/libsqlite3.so.0 $ROOTFS/usr/lib/libsqlite3.so.0
+cp $BASEDIR/../sqlite/libsqlite3.so.0 $ROOTFS/usr/lib/libsqlite3.so.0
 }
 
 main

--- a/python3x/module.py
+++ b/python3x/module.py
@@ -1,4 +1,9 @@
 from osv.modules import api
 
+#For a proper interactive python terminal
 api.require('unknown-term')
+
+#For sqlite3 and help()
+api.require('sqlite')
+
 default = api.run(cmdline="--env=TERM=unknown /python3")

--- a/sqlite/GET
+++ b/sqlite/GET
@@ -9,4 +9,4 @@ wget -c http://www.sqlite.org/$YEAR/sqlite-amalgamation-$VERSION.zip
 unzip -x sqlite-amalgamation-$VERSION.zip
 cd -
 
-cc -O2 -fPIC -Wall -shared -DHAVE_MREMAP=0 -o sqlite.so upstream/sqlite-amalgamation-$VERSION/*.c
+cc -O2 -fPIC -Wall -shared -DHAVE_MREMAP=0 -o libsqlite3.so.0 upstream/sqlite-amalgamation-$VERSION/*.c

--- a/sqlite/GET
+++ b/sqlite/GET
@@ -1,7 +1,7 @@
 #!/bin/sh
 
-YEAR=2013
-VERSION=3080200
+YEAR=2019
+VERSION=3270200
 
 mkdir upstream
 cd upstream

--- a/sqlite/Makefile
+++ b/sqlite/Makefile
@@ -6,4 +6,4 @@ upstream:
 
 .PHONY: clean
 clean:
-	rm -rf upstream *.so
+	rm -rf upstream *.so *.so.0

--- a/sqlite/module.py
+++ b/sqlite/module.py
@@ -1,3 +1,3 @@
 from osv.modules import api
 
-default = api.run("/tools/sqlite.so test.db")
+default = api.run("/usr/lib/libsqlite3.so.0 test.db")

--- a/sqlite/usr.manifest
+++ b/sqlite/usr.manifest
@@ -1,1 +1,1 @@
-/tools/sqlite.so: ${MODULE_DIR}/sqlite.so
+/usr/lib/libsqlite3.so.0: ${MODULE_DIR}/libsqlite3.so.0


### PR DESCRIPTION
As discussed in #62.

Changes to `python3x/module.py` and `python3x/GET` can be reverted when https://github.com/cloudius-systems/osv/issues/184 is closed, as they will no longer be useful.