### PR TITLE
Update Kafka verison to 2.12-2.1.1

### DIFF
--- a/apache-kafka/Capstanfile
+++ b/apache-kafka/Capstanfile
@@ -21,7 +21,7 @@ cmdline: >
   -Dcom.sun.management.jmxremote.ssl=false 
   -Dkafka.logs.dir=/kafka/logs 
   -Dlog4j.configuration=file:/kafka/config/log4j.properties 
-  -cp :/kafka/core/build/dependant-libs-2.10.4*/*.jar:/kafka/contrib/hadoop-consumer/build/libs/kafka-hadoop-consumer*.jar:/kafka/contrib/hadoop-producer/build/libs/kafka-hadoop-producer*.jar:/kafka/clients/build/libs/kafka-clients*.jar:/kafka/libs/jopt-simple-3.2.jar:/kafka/libs/kafka_2.10-0.8.2.1.jar:/kafka/libs/kafka-clients-0.8.2.1.jar:/kafka/libs/log4j-1.2.16.jar:/kafka/libs/lz4-1.2.0.jar:/kafka/libs/metrics-core-2.2.0.jar:/kafka/libs/scala-library-2.10.4.jar:/kafka/libs/slf4j-api-1.7.6.jar:/kafka/libs/slf4j-log4j12-1.6.1.jar:/kafka/libs/snappy-java-1.1.1.6.jar:/kafka/libs/zkclient-0.3.jar:/kafka/libs/zookeeper-3.4.6.jar:/kafka/core/build/libs/kafka_2.10*.jar 
+  -cp :/kafka/libs/*  
   kafka.Kafka /kafka/config/server.properties
 
 build: make

--- a/apache-kafka/Makefile
+++ b/apache-kafka/Makefile
@@ -1,5 +1,5 @@
-SCALA:=2.10
-VERSION:=0.8.2.1
+SCALA:=2.12
+VERSION:=2.1.1
 NAME:=kafka
 DIR:=kafka_$(SCALA)-$(VERSION)
 TARBALL:=$(DIR).tgz

--- a/apache-kafka/README
+++ b/apache-kafka/README
@@ -2,3 +2,7 @@ Apache Kafka OSv
 ================
 
 Apache Kafka: A high-throughput distributed messaging system. See more at http://kafka.apache.org/.
+
+Curent version of this module is Kafka 2.12-2.1.1, which is based on Scala 2.12 and needs Java 8 at minimum.
+
+Notice that in order for Kafka to work you also need to run Zookeeper and configure its IP and port in Kafka's config file (assets/config/server.properties). If you are willing to run a local OSv instance of Zookeeper, keep in mind to run it in network bridge mode.

--- a/apache-kafka/module.py
+++ b/apache-kafka/module.py
@@ -1,6 +1,6 @@
 from osv.modules import api
 
-api.require('java')
+api.require('java8')
 
 default = api.run(
     '--cwd=/kafka '
@@ -23,6 +23,6 @@ default = api.run(
     '-Dcom.sun.management.jmxremote.ssl=false '
     '-Dkafka.logs.dir=/kafka/logs '
     '-Dlog4j.configuration=file:/kafka/config/log4j.properties '
-    '-cp :/kafka/core/build/dependant-libs-2.10.4*/*.jar:/kafka/contrib/hadoop-consumer/build/libs/kafka-hadoop-consumer*.jar:/kafka/contrib/hadoop-producer/build/libs/kafka-hadoop-producer*.jar:/kafka/clients/build/libs/kafka-clients*.jar:/kafka/libs/jopt-simple-3.2.jar:/kafka/libs/kafka_2.10-0.8.2.1.jar:/kafka/libs/kafka-clients-0.8.2.1.jar:/kafka/libs/log4j-1.2.16.jar:/kafka/libs/lz4-1.2.0.jar:/kafka/libs/metrics-core-2.2.0.jar:/kafka/libs/scala-library-2.10.4.jar:/kafka/libs/slf4j-api-1.7.6.jar:/kafka/libs/slf4j-log4j12-1.6.1.jar:/kafka/libs/snappy-java-1.1.1.6.jar:/kafka/libs/zkclient-0.3.jar:/kafka/libs/zookeeper-3.4.6.jar:/kafka/core/build/libs/kafka_2.10*.jar '
+    '-cp :/kafka/libs/* '
     'kafka.Kafka /kafka/config/server.properties'
 )


### PR DESCRIPTION
Previous Kafka version was 4 years old and not compatible with
some clients, e.g., Python confluent_kafka lib.
Also adds a few instructions on how to build and run OSv Kafka
to README.