### PR TITLE
Don't include static libraries in mysql images

### DIFF
--- a/mysql/GET
+++ b/mysql/GET
@@ -46,3 +46,5 @@ echo "
 /usr/data/**: ${ROOTDIR}/usr/data/**
 /usr/bin/mysqld: ${BUILDDIR}/sql/mysqld
 " > usr.manifest
+
+find $ROOTDIR -name '*.a' -exec rm '{}' +


### PR DESCRIPTION
Static libraries have been removed from `mysql` images. This speeds up the build process and shrinks the resulting image. All credit for the idea to @wkozaczuk, based on https://github.com/cloudius-systems/osv-apps/pull/64#issuecomment-472530386