### PR TITLE
fix GraalVM example Makefile

### DIFF
--- a/graalvm-example/Makefile
+++ b/graalvm-example/Makefile
@@ -2,10 +2,10 @@ module: hello
 
 include common.gmk
 
-Hello.class: Hello.java upstream/graalvm-ce-java11-$(GRAAL_VERSION)
+Hello.class: Hello.java $(app-dir)/upstream/graalvm-ce-java11-$(GRAAL_VERSION)
 	upstream/graalvm-ce-java11-$(GRAAL_VERSION)/bin/javac -d . Hello.java
 
-hello: Hello.class upstream/graalvm-ce-java11-$(GRAAL_VERSION)/bin/native-image
+hello: Hello.class $(app-dir)/upstream/graalvm-ce-java11-$(GRAAL_VERSION)/bin/native-image
 	upstream/graalvm-ce-java11-$(GRAAL_VERSION)/bin/native-image --no-server Hello
 
 clean:


### PR DESCRIPTION
I am on Linux Ubuntu and make did not manage to resolve the target. This fixes it (that is how the target are defined in the common.gmk file).